### PR TITLE
feat(homologacao):  add GPLv3 license as default project license

### DIFF
--- a/src/plugins/woocommerce-malga-payments/woocommerce-malga-payments.php
+++ b/src/plugins/woocommerce-malga-payments/woocommerce-malga-payments.php
@@ -5,7 +5,7 @@
  * Description: Take credit card payments on your store using Malga.
  * Author: Malga Team
  * Author URI: https://www.malga.io/
- * License: GPL v3
+ * License: GPLv2
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Version: 1.0.0
  * Requires at least: 5.6

--- a/src/plugins/woocommerce-malga-payments/woocommerce-malga-payments.php
+++ b/src/plugins/woocommerce-malga-payments/woocommerce-malga-payments.php
@@ -5,6 +5,8 @@
  * Description: Take credit card payments on your store using Malga.
  * Author: Malga Team
  * Author URI: https://www.malga.io/
+ * License: GPL v3
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Version: 1.0.0
  * Requires at least: 5.6
  * Tested up to: 6.4

--- a/src/plugins/woocommerce-malga-payments/woocommerce-malga-payments.php
+++ b/src/plugins/woocommerce-malga-payments/woocommerce-malga-payments.php
@@ -5,8 +5,8 @@
  * Description: Take credit card payments on your store using Malga.
  * Author: Malga Team
  * Author URI: https://www.malga.io/
- * License: GPLv2
- * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Version: 1.0.0
  * Requires at least: 5.6
  * Tested up to: 6.4


### PR DESCRIPTION
## Motivação

 **No GPL-compatible license declared**

Durante a homologação, fomos rejeitados por não possuir licensa GPL compátivel. Agora temos.

## Links

[Task no Jira](https://malga.atlassian.net/jira/software/c/projects/LEGO/boards/39?assignee=63ce946895cff7f585c2bfa7&selectedIssue=LEGO-155)