### PR TITLE
feat(homologacao): templates now exit if they are not accessed by absolute path

### DIFF
--- a/src/plugins/woocommerce-malga-payments/templates/admin-page.php
+++ b/src/plugins/woocommerce-malga-payments/templates/admin-page.php
@@ -1,3 +1,5 @@
+<?php if ( ! defined( 'ABSPATH' ) ) exit; ?>
+
 <h3><?php echo esc_html( $this->method_title ); ?></h3>
 
 <?php

--- a/src/plugins/woocommerce-malga-payments/templates/receipt/boleto.php
+++ b/src/plugins/woocommerce-malga-payments/templates/receipt/boleto.php
@@ -1,3 +1,4 @@
+<?php if ( ! defined( 'ABSPATH' ) ) exit; ?>
 
 <h2>Boleto disponível para pagamento!</h2>
 <div class="order_details" style="padding: 20px;position: relative;">

--- a/src/plugins/woocommerce-malga-payments/templates/receipt/pix.php
+++ b/src/plugins/woocommerce-malga-payments/templates/receipt/pix.php
@@ -1,3 +1,5 @@
+<?php if ( ! defined( 'ABSPATH' ) ) exit; ?>
+ 
  <style>
     .container {
         display: flex;


### PR DESCRIPTION
## Motivação

Acesso direto é quando um usuário acessa um arquivo específico do seu plugin.
Para tal, basta usar a URL completa no browser ou fazer um POST request diretamente para o arquivo.

**O acesso direto de arquivos pode induzir bugs,** principalmente se o código executar funções.
Se é um código que contém somente classe, está ok.

Podemos evitar o acesso direto de arquivos com:

`if ( ! defined( 'ABSPATH' ) ) exit;`

## Links

[Task no Jira](https://malga.atlassian.net/jira/software/c/projects/LEGO/boards/39?selectedIssue=LEGO-157)