### PR TITLE
feat: scaping variables

### DIFF
--- a/src/plugins/woocommerce-malga-payments/templates/admin-page.php
+++ b/src/plugins/woocommerce-malga-payments/templates/admin-page.php
@@ -24,6 +24,4 @@
 	<?php $this->generate_settings_html(); ?>
 </table>
 
-<!-- 
-    plugin_locale: <?php echo apply_filters( 'plugin_locale', determine_locale(), 'malga-payments-gateway' ); ?>
--->
+<?php echo esc_html(apply_filters( 'plugin_locale', determine_locale(), 'malga-payments-gateway' )); ?>

--- a/src/plugins/woocommerce-malga-payments/templates/payment-types/credit.php
+++ b/src/plugins/woocommerce-malga-payments/templates/payment-types/credit.php
@@ -36,7 +36,7 @@
                         break;
                 }
             ?>
-            <small><?php echo sprintf(__( 'the minimum value of the installment is %s.', 'malga-payments-gateway' ), esc_attr($minimum_value)); ?></small>
+            <small><?php echo esc_html(sprintf(__( 'the minimum value of the installment is %s.', 'malga-payments-gateway' ), esc_attr($minimum_value))); ?></small>
         </label>
         <select id="malgapayments-card-installments" name="malgapayments_card_installments" style="font-size: 1.5em; padding: 4px; width: 100%;">
             <?php 


### PR DESCRIPTION
## Motivação

**Recebido do e-mail (traduzido e resumido):**

Certifique-se de escapar todas as variáveis e opções ao dar ‘echo’ nelas, para evitar vulnerabilidades XSS. Isso significa escapar no momento em que são ecoadas, não ao construir a variável. Lembre-se de que as funções de sanitização e escape não são intercambiáveis.

Mesmo que tenha sanitizado ao salvar, é crucial escapar ao ‘echo'. 

Diretamente do e-mail, exemplos de onde mudar no nosso código:


```
woocommerce-malga-payments/templates/admin-page.php:28 plugin_locale: <?php echo apply_filters( 'plugin_locale', determine_locale(), 'malga-payments-gateway' ); ?>
woocommerce-malga-payments/templates/payment-types/credit.php:39 <small><?php echo sprintf(__( 'the minimum value of the installment is %s.', 'malga-payments-gateway' ), esc_attr($minimum_value)); ?></small>

```


Note: The function__retrieves the translation without escaping, please either:

Use an alternative function that escapes the resulting value such as esc_html__ or esc_attr__.

Or wrap the __ function with a proper escaping function such as esc_html, esc_attr, wp_kses_post, etc.

Examples:

```
<h2><?php echo esc_html__('Settings page', 'plugin-slug'); ?></h2>
 <h2><?php echo esc_html(__('Settings page', 'plugin-slug')); ?></h2> 
```

Example(s) from your plugin:

`woocommerce-malga-payments/templates/payment-types/credit.php:39 <small><?php echo sprintf(__( 'the minimum value of the installment is %s.', 'malga-payments-gateway' ), esc_attr($minimum_value)); ?></small>`

---

## Detalhes

Removi a parte do código que tava estava comentando o plugin_locale, que serve para definir o locale, para as traduções. Removi por imaginar que está funcionando e que não deveria estar comentado.

Portanto:

## PENDÊNCIA:

- [ ] VERIFICAR O CAMINHO: REMOVER O CÓDIGO OU REMOVER O COMENTÁRIO