### PR TITLE
feat: add correct translation

### DIFF
--- a/src/plugins/woocommerce-malga-payments/includes/class-malga-gateway.php
+++ b/src/plugins/woocommerce-malga-payments/includes/class-malga-gateway.php
@@ -351,7 +351,7 @@ class Malga_Gateway extends WC_Payment_Gateway {
 		if(!empty($fees)){
 			foreach($this->feeOfTypes as $key => $value){
 				foreach ($fees as $key => $fee) {
-					if($fees[$key]->name === sprintf(esc_html__( $key . " discount" ), esc_html($key)) ) {
+					if($fees[$key]->name === sprintf(esc_html__('Discount for %s', 'plugin-slug'), esc_html($key)) ) {
 						unset($fees[$key]);
 					}
 				}


### PR DESCRIPTION
## Motivação

Para tornar uma string traduzível em seu plugin, use: funções "gettext" com parâmetros de texto; contexto e domínio de texto definidos como strings literais; não variáveis ou chamadas de função. **Ou seja, não use variáveis.** **Elas não serão traduzidas.**

Isso garante que os tradutores possam ver as strings a serem traduzidas corretamente.

**Se desejar incluir um valor dinâmico na tradução, use um marcador de posição e substitua-o após a função gettext fazer sua mágica usando printf.**


printf(
       /* translators: %s: First name of the user */
       esc_html__( 'Hello %s, how are you?', 'plugin-slug' ),
       esc_html( $user_firstname )
 );

[SOLUÇÃO IMPLEMENTADA FOI ESTA]


You can read https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains  for more information.

Example(s) from your plugin:

`woocommerce-malga-payments/includes/class-malga-gateway.php:354 esc_html__($key . " discount");`