### PR TITLE
feat: now processing POST correctly and sanitized variables

### DIFF
--- a/src/plugins/woocommerce-malga-payments/includes/class-malga-api.php
+++ b/src/plugins/woocommerce-malga-payments/includes/class-malga-api.php
@@ -12,8 +12,8 @@ class Malga_API {
 		return intval(str_replace(array(' ', ',', '.'), '', $value));
 	}
 
-    public function payment_request( $order, $posted ) {
-		$payment_method = isset( $posted['paymentType'] ) ? $posted['paymentType'] : '';
+    public function payment_request( $order ) {
+		$payment_method = isset( $_POST['paymentType'] ) ? $_POST['paymentType'] : '';
 
 		if ( ! in_array( $payment_method, $this->gateway->allowedTypes ) ) {
 			return array(
@@ -23,12 +23,12 @@ class Malga_API {
 			);
 		}	
 
-		$adapter = new Malga_Charges_Adapter( $this, $order, $_POST);
+		$adapter = new Malga_Charges_Adapter( $this, $order);
 
 		call_user_func_array(array($adapter, 'to_' . $payment_method), array($_POST));
 
 		if( 'yes' == $this->gateway->fraudanalysis ){
-			$adapter->set_fraudanalysis($_POST, $order);
+			$adapter->set_fraudanalysis($order);
 		}
 
         $payment_flow = apply_filters( 'malga_payment_flow', false, $order, $_POST );

--- a/src/plugins/woocommerce-malga-payments/includes/class-malga-api.php
+++ b/src/plugins/woocommerce-malga-payments/includes/class-malga-api.php
@@ -25,13 +25,13 @@ class Malga_API {
 
 		$adapter = new Malga_Charges_Adapter( $this, $order);
 
-		call_user_func_array(array($adapter, 'to_' . $payment_method), array($_POST));
+		call_user_func_array(array($adapter, 'to_' . $payment_method), array());
 
 		if( 'yes' == $this->gateway->fraudanalysis ){
 			$adapter->set_fraudanalysis($order);
 		}
 
-        $payment_flow = apply_filters( 'malga_payment_flow', false, $order, $_POST );
+        $payment_flow = apply_filters( 'malga_payment_flow', false, $order );
 		if( $payment_flow ){
 			$adapter->set_payment_flow($payment_flow);
 		}

--- a/src/plugins/woocommerce-malga-payments/includes/class-malga-charges-adapter.php
+++ b/src/plugins/woocommerce-malga-payments/includes/class-malga-charges-adapter.php
@@ -2,7 +2,7 @@
 class Malga_Charges_Adapter {
     public $gateway, $payload;
 
-	public function __construct($api, $order, $post) {
+	public function __construct($api, $order) {
         $this->gateway = $api->gateway;   
         
         if(!isset($_SERVER['HTTP_USER_AGENT'])){
@@ -15,7 +15,7 @@ class Malga_Charges_Adapter {
 			"statementDescriptor" => $this->gateway->statement_descriptor,
 			"capture" => true,
 			"orderId" => $order->get_order_number(),
-			"paymentMethod" => ["paymentType"=> sanitize_text_field($post['paymentType'])],
+			"paymentMethod" => ["paymentType"=> sanitize_text_field($_POST['paymentType'])],
             "appInfo" => [
                 "platform" => [
                    "integrator" => "malga",
@@ -34,16 +34,19 @@ class Malga_Charges_Adapter {
 		);    
     }
 
-    private function get_document( $post ) {
-        if (isset($post['billing_persontype']) && !empty($post['billing_persontype'])){
-            $document_type = ($post['billing_persontype'] == '1')? 'cpf' : 'cnpj';
-            $document_number = ($post['billing_persontype'] == '1')? $post['billing_cpf'] : $post['billing_cnpj'];
-        } else if (isset($post['billing_cpf']) && !empty($post['billing_cpf'])){
-            $document_type = 'cpf';
-            $document_number = $post['billing_cpf'];
-        } else if (isset($post['billing_cnpj']) && !empty($post['billing_cnpj'])){
-            $document_type = 'cnpj';
-            $document_number = $post['billing_cnpj'];
+    private function get_document() {
+        if (isset($_POST['billing_persontype']) && !empty($_POST['billing_persontype'])){
+            $document_type = ($_POST['billing_persontype'] == '1')? 'cpf' : 'cnpj';
+            $document_number = ($_POST['billing_persontype'] == '1')? $_POST['billing_cpf'] : $_POST['billing_cnpj'];
+        } else {
+            if (isset($_POST['billing_cpf']) && !empty($_POST['billing_cpf'])){
+                $document_type = 'cpf';
+                $document_number = $_POST['billing_cpf'];
+            }
+            if (isset($_POST['billing_cnpj']) && !empty($_POST['billing_cnpj'])){
+                $document_type = 'cnpj';
+                $document_number = $_POST['billing_cnpj'];
+            }
         }
 
         $document_number = str_replace(array('.',',','-','/'), '', $document_number);
@@ -51,12 +54,12 @@ class Malga_Charges_Adapter {
         return array($document_type, sanitize_text_field($document_number));
     }
 
-    public function set_fraudanalysis( $post, $order ) {
-        list($document_type, $document_number) = $this->get_document($post);
+    public function set_fraudanalysis($order) {
+        list($document_type, $document_number) = $this->get_document($_POST);
 
-        $district = sanitize_text_field($post['billing_neighborhood']);
-        if(empty($district)){$district = sanitize_text_field($post['billing_address_2']);};
-        if(empty($district)){$district = sanitize_text_field($post['billing_address_1']);};
+        $district = sanitize_text_field($_POST['billing_neighborhood']);
+        if(empty($district)){$district = sanitize_text_field($_POST['billing_address_2']);};
+        if(empty($district)){$district = sanitize_text_field($_POST['billing_address_1']);};
 
         if(empty($document_type))
             $document_type = 'NoDocument'; 
@@ -66,19 +69,19 @@ class Malga_Charges_Adapter {
         if($this->payload['paymentSource']['sourceType'] == "card"){
             $this->payload['fraudAnalysis'] = [
                 "customer"=> [
-                    "name"=> sanitize_text_field($post['billing_first_name'] . ' ' . $post['billing_last_name']),
+                    "name"=> sanitize_text_field($_POST['billing_first_name'] . ' ' . $_POST['billing_last_name']),
                     "identity"=> $document_number,
                     "identityType"=> $document_type,
-                    "email"=> sanitize_email($post['billing_email']),
-                    "phone"=> sanitize_text_field($post['billing_phone']),
+                    "email"=> sanitize_email($_POST['billing_email']),
+                    "phone"=> sanitize_text_field($_POST['billing_phone']),
                     "billingAddress"=> [
-                        'street' => sanitize_text_field($post['billing_address_1']),
-                        'number' => sanitize_text_field($post['billing_number']),
-                        'zipCode' => sanitize_text_field($post['billing_postcode']),
-                        'city' => sanitize_text_field($post['billing_city']),
-                        'state' => sanitize_text_field($post['billing_state']),
-                        'country' => sanitize_text_field($post['billing_country']),
-                        "complement"=> sanitize_text_field($post['billing_address_2']), 
+                        'street' => sanitize_text_field($_POST['billing_address_1']),
+                        'number' => sanitize_text_field($_POST['billing_number']),
+                        'zipCode' => sanitize_text_field($_POST['billing_postcode']),
+                        'city' => sanitize_text_field($_POST['billing_city']),
+                        'state' => sanitize_text_field($_POST['billing_state']),
+                        'country' => sanitize_text_field($_POST['billing_country']),
+                        "complement"=> sanitize_text_field($_POST['billing_address_2']), 
                         'district' => $district,
                     ]
                 ],
@@ -103,43 +106,43 @@ class Malga_Charges_Adapter {
         $this->payload['paymentFlow']['metadata'] = $metadata;
     }
 
-    public function to_credit( $post ) {
-        if(!isset($post['malgapayments_card_installments'])) $post['malgapayments_card_installments'] = "1";
+    public function to_credit() {
+        if(!isset($_POST['malgapayments_card_installments'])) $_POST['malgapayments_card_installments'] = "1";
 
-		$post['malgapayments_card_expiry'] = str_replace(array(' '), '', sanitize_text_field($post['malgapayments_card_expiry']));		
-		$post['malgapayments_card_number'] = str_replace(array(' '), '', sanitize_text_field($post['malgapayments_card_number']));  
+		$_POST['malgapayments_card_expiry'] = str_replace(array(' '), '', sanitize_text_field($_POST['malgapayments_card_expiry']));		
+		$_POST['malgapayments_card_number'] = str_replace(array(' '), '', sanitize_text_field($_POST['malgapayments_card_number']));  
 
         $this->payload['paymentSource'] = array(
             "sourceType" => "card",
             "card"=> array(
-                "cardNumber"=> sanitize_text_field($post['malgapayments_card_number']),
-                "cardCvv"=> sanitize_text_field($post['malgapayments_card_cvv']),
-                "cardExpirationDate"=> sanitize_text_field($post['malgapayments_card_expiry']),
-                "cardHolderName"=> sanitize_text_field($post['malgapayments_card_holder_name'])
+                "cardNumber"=> sanitize_text_field($_POST['malgapayments_card_number']),
+                "cardCvv"=> sanitize_text_field($_POST['malgapayments_card_cvv']),
+                "cardExpirationDate"=> sanitize_text_field($_POST['malgapayments_card_expiry']),
+                "cardHolderName"=> sanitize_text_field($_POST['malgapayments_card_holder_name'])
             )
         );
 
-        $this->payload['paymentMethod']['installments'] = intval($post['malgapayments_card_installments']);
+        $this->payload['paymentMethod']['installments'] = intval($_POST['malgapayments_card_installments']);
         $this->payload["currency"] = $this->gateway->currency;
     }
 
-    public function to_pix( $post ) {
-        list($document_type, $document_number) = $this->get_document($post);
+    public function to_pix() {
+        list($document_type, $document_number) = $this->get_document($_POST);
 
         $this->payload['paymentSource'] = array(
             "sourceType" => "customer",
             "customer"=> array(
-                "name"=> sanitize_text_field($post['billing_first_name'] . ' ' . $post['billing_last_name']),
-                "phoneNumber"=> sanitize_text_field($post['billing_phone']),
-                "email"=> sanitize_email($post['billing_email']),
+                "name"=> sanitize_text_field($_POST['billing_first_name'] . ' ' . $_POST['billing_last_name']),
+                "phoneNumber"=> sanitize_text_field($_POST['billing_phone']),
+                "email"=> sanitize_email($_POST['billing_email']),
 				"address"=> array(
-					"street"=> sanitize_text_field($post['billing_address_1']), 
-					"streetNumber"=> sanitize_text_field($post['billing_number']), 
-					"zipCode"=> sanitize_text_field($post['billing_postcode']), 
-					"country"=> sanitize_text_field($post['billing_country']), 
-					"state"=> sanitize_text_field($post['billing_state']), 
-					"district"=> sanitize_text_field($post['billing_neighborhood']), 
-					"city"=> sanitize_text_field($post['billing_city'])
+					"street"=> sanitize_text_field($_POST['billing_address_1']), 
+					"streetNumber"=> sanitize_text_field($_POST['billing_number']), 
+					"zipCode"=> sanitize_text_field($_POST['billing_postcode']), 
+					"country"=> sanitize_text_field($_POST['billing_country']), 
+					"state"=> sanitize_text_field($_POST['billing_state']), 
+					"district"=> sanitize_text_field($_POST['billing_neighborhood']), 
+					"city"=> sanitize_text_field($_POST['billing_city'])
 				),				
                 "document"=> array(
                     "number"=> $document_number,
@@ -152,7 +155,7 @@ class Malga_Charges_Adapter {
     }      
 
 
-    public function to_boleto( $post ) {
+    public function to_boleto() {
         $boleto_expires = sanitize_text_field($this->gateway->get_option( 'boleto_expires', 5 ));
         $boleto_instructions = $this->gateway->get_option( 'boleto_instructions', 'Instruções para pagamento do boleto' );
         $boleto_instructions = sanitize_text_field($boleto_instructions);
@@ -161,22 +164,22 @@ class Malga_Charges_Adapter {
         $fine_value = intval(sanitize_text_field($this->gateway->get_option( 'fine_value', 5 )));
         $fine_days = intval(sanitize_text_field($this->gateway->get_option( 'fine_days', 5 )));
 
-        list($document_type, $document_number) = $this->get_document($post);
+        list($document_type, $document_number) = $this->get_document($_POST);
 
         $this->payload['paymentSource'] = array(
             "sourceType" => "customer",
             "customer"=> array(
-                "name"=> sanitize_text_field($post['billing_first_name'] . ' ' . $post['billing_last_name']),
-                "phoneNumber"=> sanitize_text_field($post['billing_phone']),
-                "email"=> sanitize_email($post['billing_email']),
+                "name"=> sanitize_text_field($_POST['billing_first_name'] . ' ' . $_POST['billing_last_name']),
+                "phoneNumber"=> sanitize_text_field($_POST['billing_phone']),
+                "email"=> sanitize_email($_POST['billing_email']),
 				"address"=> array(
-					"street"=> sanitize_text_field($post['billing_address_1']), 
-					"streetNumber"=> sanitize_text_field($post['billing_number']), 
-					"zipCode"=> sanitize_text_field($post['billing_postcode']), 
-					"country"=> sanitize_text_field($post['billing_country']), 
-					"state"=> sanitize_text_field($post['billing_state']), 
-					"district"=> sanitize_text_field($post['billing_neighborhood']), 
-					"city"=> sanitize_text_field($post['billing_city'])
+					"street"=> sanitize_text_field($_POST['billing_address_1']), 
+					"streetNumber"=> sanitize_text_field($_POST['billing_number']), 
+					"zipCode"=> sanitize_text_field($_POST['billing_postcode']), 
+					"country"=> sanitize_text_field($_POST['billing_country']), 
+					"state"=> sanitize_text_field($_POST['billing_state']), 
+					"district"=> sanitize_text_field($_POST['billing_neighborhood']), 
+					"city"=> sanitize_text_field($_POST['billing_city'])
 				),
                 "document"=> array(
                     "number"=> $document_number,

--- a/src/plugins/woocommerce-malga-payments/includes/class-malga-charges-adapter.php
+++ b/src/plugins/woocommerce-malga-payments/includes/class-malga-charges-adapter.php
@@ -24,7 +24,7 @@ class Malga_Charges_Adapter {
                 ],
                 "device" => [
                    "name" => "browser",
-                   "version" => $_SERVER['HTTP_USER_AGENT']
+                   "version" => sanitize_text_field($_SERVER['HTTP_USER_AGENT'])
                 ],
                 "system" => [
                    "name" => "woocommerce",

--- a/src/plugins/woocommerce-malga-payments/includes/class-malga-gateway.php
+++ b/src/plugins/woocommerce-malga-payments/includes/class-malga-gateway.php
@@ -210,7 +210,7 @@ class Malga_Gateway extends WC_Payment_Gateway {
 		$isOrderIdDefined = isset($_POST['data']['orderId']);
 
 		if (isTransactionDefined && isOrderIdDefined){
-			$order = wc_get_order($_POST['data']['orderId'])
+			$order = wc_get_order($_POST['data']['orderId']);
 			$payment = $_POST['data'];
 
 			if (isset($order) && isset($payment)) {

--- a/src/plugins/woocommerce-malga-payments/includes/class-malga-gateway.php
+++ b/src/plugins/woocommerce-malga-payments/includes/class-malga-gateway.php
@@ -205,18 +205,19 @@ class Malga_Gateway extends WC_Payment_Gateway {
 		}
 	}
 
-	public function ipn_handler() {	
-		$data = json_decode(file_get_contents('php://input'), true);
-		$this->ipn_validate($data);
+	public function ipn_handler() {
+		$isTransactionDefined = isset($_POST['data']) && $_POST['data'] == 'transaction';
+		$isOrderIdDefined = isset($_POST['data']['orderId']);
 
-		if($data['object'] == 'transaction'){
-			$payment = $data['data'];
-			$order = wc_get_order( $data['data']['orderId'] );
-			if($order && $payment){
-				$this->update_order_status( $order, $payment );
-				$this->save_payment_meta_data( $order, $payment );					
+		if (isTransactionDefined && isOrderIdDefined){
+			$order = wc_get_order($_POST['data']['orderId'])
+			$payment = $_POST['data'];
+
+			if (isset($order) && isset($payment)) {
+				$this->update_order_status($order, $payment);
+				$this->save_payment_meta_data($order, $payment);					
 			}
-		}
+		}		
 		exit;
 	}
 
@@ -383,7 +384,7 @@ class Malga_Gateway extends WC_Payment_Gateway {
 		$order = wc_get_order( $order_id );	
 		$this->set_fees( $order ); 
 
-		$response = $this->api->payment_request( $order, $_POST );	
+		$response = $this->api->payment_request( $order );	
 		if ( !empty($response['data']) ) {
 			$this->update_order_status( $order, $response['data'] );
 			$this->save_payment_meta_data( $order, $response['data'] );

--- a/src/plugins/woocommerce-malga-payments/includes/class-malga-gateway.php
+++ b/src/plugins/woocommerce-malga-payments/includes/class-malga-gateway.php
@@ -360,7 +360,7 @@ class Malga_Gateway extends WC_Payment_Gateway {
 			$order->set_fees($fees);
 		}
 
-		$fee = $this->feeOfTypes[$_POST['paymentType']];
+		$fee = $this->feeOfTypes[sanitize_text_field($_POST['paymentType'])];
 		if( is_numeric($fee) && $fee != '0' ){
 			$subtotal = $order->get_subtotal();
 			$percentage = intval($fee);
@@ -368,7 +368,7 @@ class Malga_Gateway extends WC_Payment_Gateway {
 			$discount   = $percentage * $subtotal / 100;			
 
 			$fee = new WC_Order_Item_Fee();
-			$fee->set_name( $_POST['paymentType'] . " discount" );
+			$fee->set_name( sanitize_text_field($_POST['paymentType']) . " discount" );
 			$fee->set_amount($discount);
 			$fee->set_total($discount);			
 			$fee->set_tax_class('');

--- a/tests/adapters-test.php
+++ b/tests/adapters-test.php
@@ -20,7 +20,7 @@ class AdaptersTest extends TestCase{
   public function testCredit(){
     $input = json_decode( file_get_contents("tests/payloads/credit/input.json"), true);
     $output = json_decode( file_get_contents("tests/payloads/credit/output.json"), true);
-    $_POST = $input
+    $_POST = $input;
 
     $adapter = new Malga_Charges_Adapter( new MockAPI(), new MockOrder());
 
@@ -35,7 +35,7 @@ class AdaptersTest extends TestCase{
   public function testPix(){
     $input = json_decode( file_get_contents("tests/payloads/pix/input.json"), true);
     $output = json_decode( file_get_contents("tests/payloads/pix/output.json"), true);
-    $_POST = $input
+    $_POST = $input;
 
     $adapter = new Malga_Charges_Adapter( new MockAPI(), new MockOrder());
 
@@ -50,7 +50,7 @@ class AdaptersTest extends TestCase{
   public function testBoleto(){    
     $input = json_decode( file_get_contents("tests/payloads/boleto/input.json"), true);
     $output = json_decode( file_get_contents("tests/payloads/boleto/output.json"), true);
-    $_POST = $input
+    $_POST = $input;
 
     $output['paymentMethod']['expiresDate'] = date('Y-m-d', strtotime('+5 days'));
    

--- a/tests/adapters-test.php
+++ b/tests/adapters-test.php
@@ -20,8 +20,9 @@ class AdaptersTest extends TestCase{
   public function testCredit(){
     $input = json_decode( file_get_contents("tests/payloads/credit/input.json"), true);
     $output = json_decode( file_get_contents("tests/payloads/credit/output.json"), true);
+    $_POST = $input
 
-    $adapter = new Malga_Charges_Adapter( new MockAPI(), new MockOrder(), $input);
+    $adapter = new Malga_Charges_Adapter( new MockAPI(), new MockOrder());
 
     $adapter->to_credit($input);
 
@@ -34,8 +35,9 @@ class AdaptersTest extends TestCase{
   public function testPix(){
     $input = json_decode( file_get_contents("tests/payloads/pix/input.json"), true);
     $output = json_decode( file_get_contents("tests/payloads/pix/output.json"), true);
+    $_POST = $input
 
-    $adapter = new Malga_Charges_Adapter( new MockAPI(), new MockOrder(), $input);
+    $adapter = new Malga_Charges_Adapter( new MockAPI(), new MockOrder());
 
     $adapter->to_pix($input);
 
@@ -48,10 +50,11 @@ class AdaptersTest extends TestCase{
   public function testBoleto(){    
     $input = json_decode( file_get_contents("tests/payloads/boleto/input.json"), true);
     $output = json_decode( file_get_contents("tests/payloads/boleto/output.json"), true);
-    
-    $output['paymentMethod']['expiresDate'] = date('Y-m-d', strtotime('+5 days'));
+    $_POST = $input
 
-    $adapter = new Malga_Charges_Adapter( new MockAPI(), new MockOrder(), $input);
+    $output['paymentMethod']['expiresDate'] = date('Y-m-d', strtotime('+5 days'));
+   
+    $adapter = new Malga_Charges_Adapter( new MockAPI(), new MockOrder());
 
     $adapter->to_boleto($input);
 


### PR DESCRIPTION
## Motivação


**NÃO PROCESSAR O INPUT INTEIRO**

**O Woocommerce recomenda NUNCA processar toda a stack/input do $_POST ou $_REQUEST ou $_GET.**

Isso faz seu plugin lento, porque cicla dados desnecessários.

**Ao contrário, use apenas os dados necessários para a sua aplicação.**

Exemplos no código onde mudar:


```
woocommerce-malga-payments/includes/class-malga-gateway.php:209 $data = json_decode(file_get_contents('php://input'), true);
woocommerce-malga-payments/includes/class-malga-api.php:26 $adapter = new Malga_Charges_Adapter( $this, $order, $_POST);
woocommerce-malga-payments/includes/class-malga-api.php:31 $adapter->set_fraudanalysis($_POST, $order);
woocommerce-malga-payments/includes/class-malga-gateway.php:386 $response = $this->api->payment_request( $order, $_POST );	
```



Ainda há mais lugares no código onde isso acontece, encontrar e alterar.

---

**”Quando você inclui chamadas POST/GET/REQUEST/FILE em seu plugin, é importante sanitizar, validar e escapar os dados.** O objetivo é evitar que um usuário envie dados incorretos pelo sistema e protegê-lo contra possíveis problemas de segurança.

**SANITIZAR:** Os dados de entrada devem ser sanitizados o mais cedo possível para reduzir a possibilidade de vulnerabilidades XSS e ataques MITM.

**VALIDAR:** Todos os dados devem ser validados, independentemente. Mesmo ao sanitizar, lembre-se de que você não quer permitir que alguém insira 'cachorro' quando apenas números são válidos.

**ESCAPAR:** Os dados de saída devem ser escapados corretamente ao serem ecoados, para evitar que eles comprometam as telas de administração. Existem várias funções esc_*() que você pode usar para garantir que não exiba dados incorretos para as pessoas.”

 

 Limpe tudo, verifique tudo, escape tudo e nunca confie que os usuários sempre inserirão dados sensatos.

Exemplo(s) do seu plugin:


```
woocommerce-malga-payments/includes/class-malga-gateway.php:386 $response = $this->api->payment_request( $order, $_POST );	
woocommerce-malga-payments/includes/class-malga-charges-adapter.php:27 "version" => $_SERVER['HTTP_USER_AGENT']
woocommerce-malga-payments/includes/class-malga-api.php:28 call_user_func_array(array($adapter, 'to_' . $payment_method), array($_POST));
woocommerce-malga-payments/includes/class-malga-api.php:34 $payment_flow = apply_filters( 'malga_payment_flow', false, $order, $_POST );
woocommerce-malga-payments/includes/class-malga-gateway.php:362 $fee = $this->feeOfTypes[$_POST['paymentType']];
woocommerce-malga-payments/includes/class-malga-api.php:26 $adapter = new Malga_Charges_Adapter( $this, $order, $_POST);
woocommerce-malga-payments/includes/class-malga-gateway.php:370 $fee->set_name( $_POST['paymentType'] . " discount" );
```



... out of a total of 9 coincidences.