### PR TITLE
fix: transparent checkout now using correct constant

### DIFF
--- a/src/plugins/woocommerce-malga-payments/templates/transparent-checkout-form.php
+++ b/src/plugins/woocommerce-malga-payments/templates/transparent-checkout-form.php
@@ -5,7 +5,7 @@ defined( 'ABSPATH' ) || exit;
 <fieldset id="malgapayments-payment-form">
 	<style>.malgapayments-method-form{display: none;}</style>
 
-	<?php foreach(WC_MALGAPAYMENTS_PAYMENTS_TYPES as $key => $label){ ?>
+	<?php foreach(MALGAPAYMENTS_PAYMENTS_TYPES as $key => $label){ ?>
 		<?php if (in_array($key, $allowedTypes)){ ?>
 			<label>
 				<input type="radio" name="paymentType" value="<?php echo esc_attr($key); ?>">


### PR DESCRIPTION
Estávamos usando uma constante errada. Alterada para a constante correta.